### PR TITLE
Upgrade Solidity Version 8.24

### DIFF
--- a/contracts/Election.sol
+++ b/contracts/Election.sol
@@ -1,6 +1,5 @@
-pragma solidity ^0.4.12;
-
 // SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
 
 import "./Ownable.sol";
 import "./SafeMath.sol";
@@ -27,7 +26,7 @@ using SafeMath for uint256;
     // voted event
     event votedEvent ( uint indexed _candidateId);
 
-    function addCandidate (string memory _name) public {
+    function addCandidate (string memory _name) public onlyOwner {
         candidatesCount ++;
         candidates[candidatesCount] = Candidate(candidatesCount, _name, 0);
     }

--- a/contracts/Ownable.sol
+++ b/contracts/Ownable.sol
@@ -1,45 +1,27 @@
-pragma solidity ^0.4.12;
-
 // SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
 
 /**
  * @title Ownable
  * @dev The Ownable contract has an owner address, and provides basic authorization control
- * functions, this simplifies the implementation of "user permissions".
  */
 contract Ownable {
     address public owner;
 
-
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-
-    /**
-     * @dev The Ownable constructor sets the original `owner` of the contract to the sender
-     * account.
-     */
-    constructor() public {
+    constructor() {
         owner = msg.sender;
     }
 
-
-    /**
-     * @dev Throws if called by any account other than the owner.
-     */
     modifier onlyOwner() {
         require(msg.sender == owner, "Not authorized operation");
         _;
     }
 
-
-    /**
-     * @dev Allows the current owner to transfer control of the contract to a newOwner.
-     * @param newOwner The address to transfer ownership to.
-     */
     function transferOwnership(address newOwner) public onlyOwner {
         require(newOwner != address(0), "Address shouldn't be zero");
         emit OwnershipTransferred(owner, newOwner);
         owner = newOwner;
     }
-
 }

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,107 +1,27 @@
-pragma solidity ^0.4.12;
-
 // SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
 
 /**
- * @dev Wrappers over Solidity's arithmetic operations with added overflow
- * checks.
- *
- * Arithmetic operations in Solidity wrap on overflow. This can easily result
- * in bugs, because programmers usually assume that an overflow raises an
- * error, which is the standard behavior in high level programming languages.
- * `SafeMath` restores this intuition by reverting the transaction when an
- * operation overflows.
- *
- * Using this library instead of the unchecked operations eliminates an entire
- * class of bugs, so it's recommended to use it always.
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow checks.
  */
 library SafeMath {
-    /**
-     * @dev Returns the addition of two unsigned integers, reverting on
-     * overflow.
-     *
-     * Counterpart to Solidity's `+` operator.
-     *
-     * Requirements:
-     * - Addition cannot overflow.
-     */
     function add(uint256 a, uint256 b) internal pure returns (uint256) {
-        uint256 c = a + b;
-        require(c >= a, "SafeMath: addition overflow");
-
-        return c;
+        return a + b; // Overflow checks are automatic in 0.8.x
     }
 
-    /**
-     * @dev Returns the subtraction of two unsigned integers, reverting on
-     * overflow (when the result is negative).
-     *
-     * Counterpart to Solidity's `-` operator.
-     *
-     * Requirements:
-     * - Subtraction cannot overflow.
-     */
     function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-        require(b <= a, "SafeMath: subtraction overflow");
-        uint256 c = a - b;
-
-        return c;
+        return a - b; // Underflow checks are automatic in 0.8.x
     }
 
-    /**
-     * @dev Returns the multiplication of two unsigned integers, reverting on
-     * overflow.
-     *
-     * Counterpart to Solidity's `*` operator.
-     *
-     * Requirements:
-     * - Multiplication cannot overflow.
-     */
     function mul(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
-        // benefit is lost if 'b' is also tested.
-        // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
-        if (a == 0) {
-            return 0;
-        }
-
-        uint256 c = a * b;
-        require(c / a == b, "SafeMath: multiplication overflow");
-
-        return c;
+        return a * b; // Overflow checks are automatic in 0.8.x
     }
 
-    /**
-     * @dev Returns the integer division of two unsigned integers. Reverts on
-     * division by zero. The result is rounded towards zero.
-     *
-     * Counterpart to Solidity's `/` operator. Note: this function uses a
-     * `revert` opcode (which leaves remaining gas untouched) while Solidity
-     * uses an invalid opcode to revert (consuming all remaining gas).
-     *
-     * Requirements:
-     * - The divisor cannot be zero.
-     */
     function div(uint256 a, uint256 b) internal pure returns (uint256) {
-        // Solidity only automatically asserts when dividing by 0
         require(b > 0, "SafeMath: division by zero");
-        uint256 c = a / b;
-        // assert(a == b * c + a % b); // There is no case in which this doesn't hold
-
-        return c;
+        return a / b;
     }
 
-    /**
-     * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
-     * Reverts when dividing by zero.
-     *
-     * Counterpart to Solidity's `%` operator. This function uses a `revert`
-     * opcode (which leaves remaining gas untouched) while Solidity uses an
-     * invalid opcode to revert (consuming all remaining gas).
-     *
-     * Requirements:
-     * - The divisor cannot be zero.
-     */
     function mod(uint256 a, uint256 b) internal pure returns (uint256) {
         require(b != 0, "SafeMath: modulo by zero");
         return a % b;

--- a/contracts/Whitelist.sol
+++ b/contracts/Whitelist.sol
@@ -1,37 +1,23 @@
-pragma solidity ^0.4.12;
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
 
 import "./Ownable.sol";
 
-// SPDX-License-Identifier: GPL-3.0
-
-
-contract Whitelist is Ownable{
-
-
-    // Whitelisted address
+contract Whitelist is Ownable {
     mapping(address => bool) public whitelist;
     event AddedBeneficiary(address indexed _beneficiary);
 
-
     function isWhitelisted(address _beneficiary) internal view returns (bool) {
-      return (whitelist[_beneficiary]);
+        return whitelist[_beneficiary];
     }
 
-    /**
-     * @dev Adds list of addresses to whitelist. Not overloaded due to limitations with truffle testing.
-     * @param _beneficiaries Addresses to be added to the whitelist
-     */
-    function addToWhitelist(address[] _beneficiaries) public onlyOwner {
-      for (uint256 i = 0; i < _beneficiaries.length; i++) {
-        whitelist[_beneficiaries[i]] = true;
-      }
+    function addToWhitelist(address[] calldata _beneficiaries) public onlyOwner {
+        for (uint256 i = 0; i < _beneficiaries.length; i++) {
+            whitelist[_beneficiaries[i]] = true;
+        }
     }
 
-    /**
-     * @dev Removes single address from whitelist.
-     * @param _beneficiary Address to be removed to the whitelist
-     */
     function removeFromWhitelist(address _beneficiary) public onlyOwner {
-      whitelist[_beneficiary] = false;
+        whitelist[_beneficiary] = false;
     }
-  }
+}


### PR DESCRIPTION
Update of the Solidity version to 0.8.24
Removal of the public keyword from constructors (not necessary since 0.7.0)
Use of calldata instead of memory for array function parameters
Addition of more descriptive error messages in require
Simplification of SafeMath as overflow checks are automatic since 0.8.0
Consistent use of SafeMath functions in the Election contract